### PR TITLE
Update web_demo2.py

### DIFF
--- a/web_demo2.py
+++ b/web_demo2.py
@@ -28,6 +28,8 @@ def predict(input, max_length, top_p, temperature, history=None):
 
     with container:
         if len(history) > 0:
+            if len(history)>MAX_BOXES:
+                history = history[-MAX_TURNS:]
             for i, (query, response) in enumerate(history):
                 message(query, avatar_style="big-smile", key=str(i) + "_user")
                 message(response, avatar_style="bottts", key=str(i))


### PR DESCRIPTION
当前MAX_BOXES与MAX_TURNS不生效导致单次对话不终止显存不断增加最后显存溢出问题，修改最大对话轮数和最大历史对话数量使其生效，逻辑为历史最大对话框记录轮数达到MAX_BOXES时截断历史对话为最近MAX_TURNS数。